### PR TITLE
fix: Ignore ping replies from unexpected source addresses on macOS

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -63,6 +63,17 @@ pub struct PingTask {
     errs: Arc<Mutex<Vec<String>>>,
 }
 
+fn ping_reply_source(line: &str) -> Option<IpAddr> {
+    let source = line
+        .split_once(" bytes from ")?
+        .1
+        .split_whitespace()
+        .next()?
+        .trim_end_matches([':', ',']);
+
+    source.parse().ok()
+}
+
 impl PingTask {
     pub fn new(
         addr: String,
@@ -114,14 +125,18 @@ impl PingTask {
                 Ok(result) => {
                     match result {
                         PingResult::Pong(duration, line) => {
-                            // macOS ping may emit duplicate replies from another concurrent
-                            // ping process. These can contain bogus RTT values and must not
-                            // be included in the statistics.
+                            if let (Some(source), Ok(target)) =
+                                (ping_reply_source(&line), self.ip.parse::<IpAddr>())
+                            {
+                                if source != target {
+                                    continue;
+                                }
+                            }
+
                             if line.contains("(DUP!)") {
                                 continue;
                             }
 
-                            // calculate rtt
                             let rtt = duration.as_secs_f64() * 1000.0;
                             let rtt_display: f64 = format!("{:.2}", rtt).parse().unwrap();
                             

--- a/src/network.rs
+++ b/src/network.rs
@@ -113,7 +113,14 @@ impl PingTask {
             match stream.recv() {
                 Ok(result) => {
                     match result {
-                        PingResult::Pong(duration, _size) => {
+                        PingResult::Pong(duration, line) => {
+                            // macOS ping may emit duplicate replies from another concurrent
+                            // ping process. These can contain bogus RTT values and must not
+                            // be included in the statistics.
+                            if line.contains("(DUP!)") {
+                                continue;
+                            }
+
                             // calculate rtt
                             let rtt = duration.as_secs_f64() * 1000.0;
                             let rtt_display: f64 = format!("{:.2}", rtt).parse().unwrap();


### PR DESCRIPTION
## Summary

On macOS, the system `ping` command can occasionally emit replies belonging
to another concurrent ping process. These replies may contain absurd RTT
values and are then parsed by `pinger` as valid `Pong` results, contaminating
NBping's Max, Avg, and Jitter statistics.

The initial version of this PR filtered replies marked with `(DUP!)`, because
all early reproductions had that marker. Further testing showed that the marker
is not reliable: wrong-source replies can also occur without `(DUP!)`.

Example without `(DUP!)`:

    target       : 10.77.0.1
    reply source : 192.168.178.1
    raw          : 56 bytes from 192.168.178.1: icmp_seq=0 ttl=64 time=1654220132216.256 ms

A second independent case was observed later:

    target       : 10.77.0.1
    reply source : 192.168.178.102
    raw          : 56 bytes from 192.168.178.102: icmp_seq=0 ttl=255 time=1654224596656.605 ms

Because the reply source clearly does not match the target, filtering only
`(DUP!)` replies is insufficient.

The updated patch therefore parses the source address from the macOS `ping`
output and ignores replies whose source IP differs from the resolved target IP.
The `(DUP!)` check remains as an additional safeguard so same-source duplicate
replies are not included in the statistics.

## Reproduction / verification

The behavior was reproduced independently with a minimal program using the
`pinger` crate directly, with both `pinger` 2.0.0 and 2.2.0.

The bogus RTT is already present in the raw output produced by the macOS
`ping` process, so it is not generated by NBping's statistics code.

During an extended multi-target NBping test of roughly 20,000 pings, the
source-address check rejected multiple wrong-source replies. Most were marked
`(DUP!)`, but at least two were not, confirming that source validation is
required.

With those replies ignored, no astronomical RTT values reached NBping's
statistics.

`cargo test` and `cargo build --release` both complete successfully.